### PR TITLE
Update README for build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ ANTHROPIC_API_KEY=your-anthropic-key
 
 These variables are required for routes under `app/api/*` that interact with the models.
 
+## Build and Lint
+
+Install dependencies before running the build or lint commands:
+
+```bash
+pnpm install
+pnpm lint
+pnpm build
+```
+


### PR DESCRIPTION
## Summary
- document build and lint commands in README
- emphasize running `pnpm install` first

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/... Forbidden - 403)*
- `pnpm lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d015cc13483308b11dfdec8e756d2