### PR TITLE
Fix toast effect registration

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent repeated listener registration in `use-toast`
- adjust effect dependency for single mount

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/... Forbidden)*
- `npx tsc` *(fails: Cannot find module 'ai', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_685d05a1f4fc83309a771a7f75576bbb