### PR TITLE
Add API key validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ ANTHROPIC_API_KEY=your-anthropic-key
 ```
 
 These variables are required for routes under `app/api/*` that interact with the models.
+If `ANTHROPIC_API_KEY` is not set (and `OPENAI_API_KEY` when using OpenAI models),
+the API routes will respond with a 500 error.
 
 ## Build and Lint
 

--- a/app/api/generate-angles/route.ts
+++ b/app/api/generate-angles/route.ts
@@ -3,6 +3,12 @@ import { anthropic } from "@ai-sdk/anthropic"
 import { NextResponse } from "next/server"
 
 export async function POST(request: Request) {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return NextResponse.json(
+      { error: "ANTHROPIC_API_KEY is not set" },
+      { status: 500 }
+    )
+  }
   try {
     const { productInput, productUrl, selectedHook } = await request.json()
 

--- a/app/api/generate-captions/route.ts
+++ b/app/api/generate-captions/route.ts
@@ -3,6 +3,12 @@ import { anthropic } from "@ai-sdk/anthropic"
 import { NextResponse } from "next/server"
 
 export async function POST(request: Request) {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return NextResponse.json(
+      { error: "ANTHROPIC_API_KEY is not set" },
+      { status: 500 }
+    )
+  }
   try {
     const { productUrl, contentType, additionalDetails } = await request.json()
 

--- a/app/api/generate-hooks/route.ts
+++ b/app/api/generate-hooks/route.ts
@@ -31,6 +31,12 @@ const HOOK_LIBRARY = [
 ]
 
 export async function POST(request: Request) {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return NextResponse.json(
+      { error: "ANTHROPIC_API_KEY is not set" },
+      { status: 500 }
+    )
+  }
   try {
     const { productInput, productUrl } = await request.json()
 

--- a/app/api/generate-script/route.ts
+++ b/app/api/generate-script/route.ts
@@ -3,6 +3,12 @@ import { anthropic } from "@ai-sdk/anthropic"
 import { NextResponse } from "next/server"
 
 export async function POST(request: Request) {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return NextResponse.json(
+      { error: "ANTHROPIC_API_KEY is not set" },
+      { status: 500 }
+    )
+  }
   try {
     const { productInput, productUrl, selectedHook, selectedAngle } = await request.json()
 


### PR DESCRIPTION
## Summary
- validate that `ANTHROPIC_API_KEY` is present in all API routes
- document the required environment variables and failure behavior

## Testing
- `pnpm install` *(fails: Forbidden - 403)*
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d05ae9ce08330a82774b86694c0ef