### PR TITLE
Add Jest setup and API route test

### DIFF
--- a/__tests__/generate-hooks.test.ts
+++ b/__tests__/generate-hooks.test.ts
@@ -1,0 +1,21 @@
+import { POST } from '../app/api/generate-hooks/route'
+import { generateText } from 'ai'
+
+jest.mock('ai', () => ({
+  generateText: jest.fn(),
+}))
+
+describe('generate-hooks API', () => {
+  it('parses JSON from generateText', async () => {
+    const mockedGenerateText = generateText as jest.MockedFunction<typeof generateText>
+    mockedGenerateText.mockResolvedValue({ text: JSON.stringify([{ id: 'hook1', text: 't', description: 'd' }]) })
+    const req = new Request('http://localhost/api/generate-hooks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ productInput: 'info', productUrl: 'url' }),
+    })
+    const res = await POST(req)
+    const data = await res.json()
+    expect(data).toEqual({ hooks: [{ id: 'hook1', text: 't', description: 'd' }] })
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.jest.json',
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "latest",
@@ -68,6 +69,9 @@
     "@types/react-dom": "^19",
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0",
+    "@types/jest": "^29.5.12"
   }
 }

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  }
+}


### PR DESCRIPTION
## Summary
- add Jest with ts-jest config
- create Jest config and tsconfig for tests
- write test for `generate-hooks` API route

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d05a6dd2083309a764b8617ca9a46